### PR TITLE
feat: add array example

### DIFF
--- a/docs/hasTypeAssertion.md
+++ b/docs/hasTypeAssertion.md
@@ -1,0 +1,40 @@
+# Has type Assertion
+
+We use the very same types as JSON Schema allows, which each has a variant in each respective language.
+
+If multiple arguments are are provided such as below, it means that the argument above the other is used as a generic input.
+```json
+{
+    "assertion": "hasType",
+    "arguments": [
+        "array",
+        "string"
+    ]
+}
+```
+In the example above it means that we have an array of strings. Restriction to this syntax is only one generic input allowed per type.
+
+
+| Type | TS | Java |
+| ----------- | ----------- | ----------- |
+| number | number | double
+| string | string | String
+| boolean | boolean | boolean
+| null | null | `JsonNull.getInstance()`
+| object | any | Object
+| array< Type > | < Type >[] | List< Type >
+
+
+## Null restrictions
+
+`null` will in many cases require a custom wrapper class to represent a null value. I.e. for Java we recommend `JsonNull`:
+
+```java
+class JsonNull {
+    static public JsonNull getInstance() {
+        return null;
+    }
+}
+```
+
+In others, such as `TS` we can use `null`.

--- a/docs/hasTypeAssertion.md
+++ b/docs/hasTypeAssertion.md
@@ -20,7 +20,7 @@ In the example above it means that we have an array of strings. Restriction to t
 | number | number | double
 | string | string | String
 | boolean | boolean | boolean
-| null | null | `JsonNull.getInstance()`
+| null | null | JsonNull
 | object | any | Object
 | array< Type > | < Type >[] | List< Type >
 

--- a/test-suite/idl-schema/arrays/arrays.json
+++ b/test-suite/idl-schema/arrays/arrays.json
@@ -1,0 +1,154 @@
+[
+  {
+    "description": "Should have accurate array",
+    "schemas": [
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/idl-schema",
+        "name": "SomeTitle",
+        "type": "object",
+        "properties": {
+          "NumberArray": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "StringArray": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "BooleanArray": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            }
+          },
+          "NullArray": {
+            "type": "array",
+            "items": {
+              "type": "null"
+            }
+          },
+          "ObjectArray": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "ObjectArrayInArray": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "assertion": "hasClass",
+        "arguments": [
+          "SomeTitle"
+        ],
+        "tests": [
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "NumberArray"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "array",
+                  "number"
+                ]
+              }
+            ]
+          },
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "StringArray"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "array",
+                  "string"
+                ]
+              }
+            ]
+          },
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "BooleanArray"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "array",
+                  "boolean"
+                ]
+              }
+            ]
+          },
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "NullArray"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "array",
+                  "null"
+                ]
+              }
+            ]
+          },
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "ObjectArray"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "array",
+                  "object"
+                ]
+              }
+            ]
+          },
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "ObjectArrayInArray"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "array",
+                  "array",
+                  "object"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds a simple array example with all the different types that can be expected.

It also adds a small doc explaining the types that are being used.


Partly fixes #14 