### PR TITLE
fix: add missing null property for tests

### DIFF
--- a/test-suite/idl-schema/properties/properties.json
+++ b/test-suite/idl-schema/properties/properties.json
@@ -70,6 +70,20 @@
                 ]
               }
             ]
+          },
+          {
+            "assertion": "hasProperty",
+            "arguments": [
+              "NullProperty"
+            ],
+            "tests": [
+              {
+                "assertion": "hasType",
+                "arguments": [
+                  "null"
+                ]
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
I forgot to add null property testing.

After #22 is merged with the explanation to the types, we can merge this.


Blocked by #22 
Fixes #15 